### PR TITLE
Add metron settings for analytics

### DIFF
--- a/djangocon/settings/base.py
+++ b/djangocon/settings/base.py
@@ -227,6 +227,20 @@ PROPOSAL_FORMS = {
     "open-space": "djangocon.proposals.forms.OpenSpaceProposalForm",
 }
 
+
+METRON_SETTINGS = {
+    "google": {
+        3: os.environ.get("GA_TOKEN"),
+    },
+    "gauges": {
+        3: os.environ.get("GAUGES_TOKEN")
+    },
+    "mixpanel": {
+        3: os.environ.get("MIXPANEL_API_TOKEN"),
+    }
+}
+
+
 SESSION_COOKIE_NAME = "DJANGOCON2015"
 
 THEME_CONTACT_EMAIL = ''

--- a/djangocon/templates/site_base.html
+++ b/djangocon/templates/site_base.html
@@ -3,6 +3,7 @@
 {% load pipeline %}
 {% load markitup_tags %}
 {% load sitetree %}
+{% load metron_tags %}
 <html lang="{{ LANGUAGE_CODE }}">
 <head>
   <meta charset="UTF-8">
@@ -119,5 +120,6 @@
   {% block extra_body_base %}
     {% block extra_body %}{% endblock extra_body %}
   {% endblock extra_body_base %}
+  {% analytics %}
 </body>
 </html>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@
 Django>1.6,<1.7
 django-mailer==0.2a1
 django-redis-cache==0.13.0
-metron==0.1 # 0.2.dev3
+metron==1.3.5 # 0.2.dev3
 pinax-utils==1.0b1.dev3
 South==1.0.2
 # pin the version based on the version used for PyOhio 2014


### PR DESCRIPTION
To finish configuration, just need to run:

```
gondor env:set primary GA_TOKEN=<TOKEN>
```

likewise if you want to setup gauges and/or mixpanel

Fixes #34
